### PR TITLE
Point to 2.0 release

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "https://github.com/Hearst-DD/ObjectMapper.git" "swift-3"
+github "https://github.com/Hearst-DD/ObjectMapper.git" ~> 2.0


### PR DESCRIPTION
ObjectMapper branch `"swift-3"` no longer exists so the project does not build via Carthage